### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
This will create Solidity syntax highlighting when the code is viewed on GitHub. It does take a min to show up tho. I had to push a new commit (added a comment to a solidity file) after adding the .gitattributes files for it to show up.
- https://medium.com/@danielque/psa-how-to-fix-githubs-syntax-highlighting-for-solidity-4e9867c540b6
- https://ethereum.stackexchange.com/questions/46641/how-do-i-get-github-to-syntax-highlight-solidity-code
